### PR TITLE
readme: add a babashka compatible badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Parser combinators for Clojure(Script).
 
 [![cljdoc badge](https://cljdoc.org/badge/com.github.strojure/parsesso)](https://cljdoc.org/d/com.github.strojure/parsesso)
 [![Clojars Project](https://img.shields.io/clojars/v/com.github.strojure/parsesso.svg)](https://clojars.org/com.github.strojure/parsesso)
+[![bb compatible](https://raw.githubusercontent.com/babashka/babashka/master/logo/badge.svg)](https://babashka.org)
 
 ## Motivation
 


### PR DESCRIPTION
To let folks know, at-a-glance, that this library also works with babashka.